### PR TITLE
Fail silently in oneshot mode.

### DIFF
--- a/main.go
+++ b/main.go
@@ -108,7 +108,7 @@ func main() {
 				}
 				if len(toProcess) == 0 {
 					glog.Infof("no resources left to process. exiting...")
-					if failedResource {
+					if failedResource && !options.oneShot {
 						os.Exit(1)
 					} else {
 						os.Exit(0)


### PR DESCRIPTION
When one running in oneShot mode  exit  silently if unable to fetch secrets. 

Typically the application is run in oneShot  mode when used as an init container.
if the application exits  with an error the main containerners are not started. 
With this change the main container will start and fail if the secrets it requires does not 
exist. This will hopefully provide better feedback. 